### PR TITLE
Longitude Optimization

### DIFF
--- a/Assets/Scripts/SphericalWorldGenerator.cs
+++ b/Assets/Scripts/SphericalWorldGenerator.cs
@@ -168,10 +168,16 @@ public class SphericalWorldGenerator : Generator {
 	// Convert Lat/Long coordinates to x/y/z for spherical mapping
 	void LatLonToXYZ(float lat, float lon, ref float x, ref float y, ref float z)
 	{
-		float r = Mathf.Cos (Mathf.Deg2Rad * lon);
-		x = r * Mathf.Cos (Mathf.Deg2Rad * lat);
-		y = Mathf.Sin (Mathf.Deg2Rad * lon);
-		z = r * Mathf.Sin (Mathf.Deg2Rad * lat);
+		float r = Mathf.Cos(Mathf.Deg2Rad * lon);
+
+		//Longitude Optimization
+		float sin = Mathf.Sqrt(1 * 1 - r * r);
+		if (lon < 0)
+		    sin = -sin;
+
+		x = r * Mathf.Cos(Mathf.Deg2Rad * lat);
+		y = sin;
+		z = r * Mathf.Sin(Mathf.Deg2Rad * lat);
 	}
     
 	protected override Tile GetTop(Tile t)


### PR DESCRIPTION
Given that longitude varies from -90 to 90 you can use pythagoras to find the sine instead of using Mathf.Sin. Generally most benchmarks show that Sqrt is cheaper than Cosine. Indeed in my test of a large map this saved 0.3 seconds.